### PR TITLE
Added #hash method to allow RJAC objects to be used as Hash keys

### DIFF
--- a/lib/ruby_json_api_client/base.rb
+++ b/lib/ruby_json_api_client/base.rb
@@ -172,6 +172,11 @@ module RubyJsonApiClient
 
       klass_match && ids_match
     end
+
+    def hash
+      self.send(self.class._identifier).hash
+    end
+
     alias_method :eql?, :==
     alias_method :equal?, :==
   end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -120,4 +120,32 @@ describe RubyJsonApiClient::Base do
       it { should eq(true) }
     end
   end
+
+  describe :hash do
+    context "two objects of different classes" do
+      subject { Person.new(id: 1).hash == Item.new(id: 1).hash }
+      it { should eq(true) }
+    end
+
+    context "two objects of the same class but different ids" do
+      subject { Person.new(id: 1).hash == Person.new(id: 2).hash }
+      it { should eq(false) }
+    end
+
+    context "two objects with the same klass and id" do
+      subject { Person.new(id: 1).hash == Person.new(id: 1).hash }
+      it { should eq(true) }
+    end
+
+    context "the same instance" do
+      let(:person) { Person.new(id: 1) }
+      subject { person.hash == person.hash }
+      it { should eq(true) }
+    end
+
+    context "two objects with non standard identifiers" do
+      subject { Thing.new(uuid: 'x').hash == Thing.new(uuid: 'x').hash }
+      it { should eq(true) }
+    end
+  end
 end


### PR DESCRIPTION
When an RJAC object is serialized itself using ActiveModel::Serializer the part that unique-ifies embedded associations wasn't working. A Registrant has one candidate_type, but the result of serializing an array of registrants was a top level candidate_types array with as many duplicate entries as there were registrants (all registrants had the same type in this case). 

Referenced https://github.com/rails-api/active_model_serializers/blob/0-8-stable/lib/active_model/serializer.rb#L445 and https://github.com/rails/rails/blob/438662ab32715d3b780fb54b0743cc2e19843086/activerecord/lib/active_record/core.rb#L398