### PR TITLE
add support for remote_class specification

### DIFF
--- a/lib/ruby_json_api_client/adapters/rest_adapter.rb
+++ b/lib/ruby_json_api_client/adapters/rest_adapter.rb
@@ -25,7 +25,7 @@ module RubyJsonApiClient
     end
 
     def single_path(klass, params = {})
-      name = klass.name
+      name = klass.remote_class
       plural = ActiveSupport::Inflector.pluralize(name)
       path = plural.underscore
       id = params[:id]
@@ -33,7 +33,7 @@ module RubyJsonApiClient
     end
 
     def collection_path(klass, params)
-      name = klass.name
+      name = klass.remote_class
       plural = ActiveSupport::Inflector.pluralize(name)
       "#{@namespace}/#{plural.underscore}"
     end

--- a/lib/ruby_json_api_client/base.rb
+++ b/lib/ruby_json_api_client/base.rb
@@ -32,6 +32,13 @@ module RubyJsonApiClient
       @_fields ||= Set.new [_identifier]
     end
 
+    def self.remote_class(name=nil)
+      if name.present?
+        @_remote_class = name
+      end
+      @_remote_class || self.to_s
+    end
+
     def self.attributes
       fields.reduce({}) do |attributes, field|
         attributes[field] = nil

--- a/lib/ruby_json_api_client/base.rb
+++ b/lib/ruby_json_api_client/base.rb
@@ -158,8 +158,10 @@ module RubyJsonApiClient
       RubyJsonApiClient::Store.instance.reload(self)
     end
 
-    def save
-      perform_validations() && RubyJsonApiClient::Store.instance.save(self)
+    def save(options={})
+      options.fetch(:validate, true) ?
+        perform_validations() && RubyJsonApiClient::Store.instance.save(self) :
+        RubyJsonApiClient::Store.instance.save(self)
     end
 
     def update_attributes(data)

--- a/lib/ruby_json_api_client/serializers/ams_serializer.rb
+++ b/lib/ruby_json_api_client/serializers/ams_serializer.rb
@@ -85,7 +85,7 @@ module RubyJsonApiClient
 
     def extract_single(klass, id, response)
       return nil if response.nil?
-      name = klass.to_s.underscore
+      name = klass.remote_class.underscore
       data = transform(response)
 
       assert data[name],
@@ -105,7 +105,7 @@ module RubyJsonApiClient
     end
 
     def extract_many(klass, response, key = nil)
-      key = klass.to_s.underscore if key.nil?
+      key = klass.remote_class.underscore if key.nil?
       plural = ActiveSupport::Inflector.pluralize(key)
 
       data = transform(response)

--- a/lib/ruby_json_api_client/serializers/ams_serializer.rb
+++ b/lib/ruby_json_api_client/serializers/ams_serializer.rb
@@ -30,7 +30,7 @@ module RubyJsonApiClient
     end
 
     def to_data(model)
-      key = model.class.to_s.underscore.downcase
+      key = model.class.remote_class.underscore.downcase
       id_field = model.class._identifier
       data = {}
       data[key] = {}

--- a/spec/support/classes.rb
+++ b/spec/support/classes.rb
@@ -27,3 +27,9 @@ end
 
 class Nothing < RubyJsonApiClient::Base
 end
+
+module LocalNamespace
+  class TestClass < RubyJsonApiClient::Base
+    remote_class "SomeOtherClass"
+  end
+end

--- a/spec/unit/adapters/rest_spec.rb
+++ b/spec/unit/adapters/rest_spec.rb
@@ -31,6 +31,11 @@ describe RubyJsonApiClient::RestAdapter do
       subject { adapter.single_path(CellPhone, { id: 3 }) }
       it { should == "testing/cell_phones/3" }
     end
+
+    context LocalNamespace::TestClass do
+      subject { adapter.single_path(LocalNamespace::TestClass, {id: 4}) }
+      it { should == "testing/some_other_classes/4"}
+    end
   end
 
   describe :collection_path do
@@ -47,6 +52,11 @@ describe RubyJsonApiClient::RestAdapter do
     context CellPhone do
       subject { adapter.collection_path(CellPhone, {}) }
       it { should == "testing/cell_phones" }
+    end
+
+    context LocalNamespace::TestClass do
+      subject { adapter.collection_path(LocalNamespace::TestClass, {}) }
+      it { should == "testing/some_other_classes" }
     end
   end
 

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -29,7 +29,7 @@ describe RubyJsonApiClient::Base do
         subject { Person.new(firstname: 'ryan').valid? }
         it { should eq(true) }
       end
-      
+
       it "should prevent creating invalid records" do
         person = Person.create({})
         expect(person.persisted?).to eq false
@@ -46,6 +46,10 @@ describe RubyJsonApiClient::Base do
         expect(person.valid?).to eq false
       end
     end
+  end
+
+  describe :remote_class do
+
   end
 
   describe :has_field? do


### PR DESCRIPTION
Needed to make a quick change to support namespaced classes without breaking the corresponding urls for the remote resources.  Let me  know if you think there's a better way to handle this or if the code was already capable of it.